### PR TITLE
Performed minimal updates to make this compile with Elm 0.18

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -13,8 +13,8 @@
         "PriorityQueue"
     ],
     "dependencies": {
-        "elm-lang/core": "4.0.1 <= v < 5.0.0",
-        "elm-lang/html": "1.0.0 <= v < 2.0.0"
+        "elm-lang/core": "5.0.0 <= v < 6.0.0",
+        "elm-lang/html": "2.0.0 <= v < 3.0.0"
     },
-    "elm-version": "0.17.0 <= v < 0.18.0"
+    "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/src/Finger.elm
+++ b/src/Finger.elm
@@ -68,18 +68,18 @@ rightRemove finger=
 leftPeak:Finger a->a
 leftPeak finger =
   case finger of
-  One a'->a'
-  Two a' _ ->a'
-  Three a' _ _-> a'
-  Four a' _ _ _ -> a'
+  One a_->a_
+  Two a_ _ ->a_
+  Three a_ _ _-> a_
+  Four a_ _ _ _ -> a_
 
 rightPeak:Finger a -> a
 rightPeak finger =
     case finger of
-    One a'->a'
-    Two _ a'  ->a'
-    Three  _ _ a'-> a'
-    Four _ _ _  a'-> a'
+    One a_->a_
+    Two _ a_  ->a_
+    Three  _ _ a_-> a_
+    Four _ _ _  a_-> a_
 
 tryFromList: List a -> Maybe (Finger a)
 tryFromList list =

--- a/src/Monoid.elm
+++ b/src/Monoid.elm
@@ -17,7 +17,7 @@ appendZero op =
     case (a1,a2) of
     (Zero,  a) -> a
     (a, Zero) -> a
-    (Normal a, Normal a') -> Normal(op a a')
+    (Normal a, Normal a_) -> Normal(op a a_)
   in
   {zero = Zero , op = newOp}
 

--- a/src/PriorityQueue.elm
+++ b/src/PriorityQueue.elm
@@ -14,7 +14,7 @@ type alias PriorityQueue a comparable=
   AnnotatedFingerTree (Monoid.WithAppendedZero (a,comparable)) (Monoid.WithAppendedZero (a,comparable))
 
 minBySnd: (a,comparable) -> (a,comparable) -> (a,comparable)
-minBySnd (a,c) (a',c')= if c'>c then (a',c') else (a,c)
+minBySnd (a,c) (a_,c_)= if c_>c then (a_,c_) else (a,c)
 {-| returns an empty priority queue-}
 empty: PriorityQueue a comparable
 empty = Annotated.empty (Monoid.appendZero minBySnd) identity


### PR DESCRIPTION
I made the minor changes described in [The migration guide to Elm 0.18](https://github.com/elm-lang/elm-platform/blob/master/upgrade-docs/0.18.md).

The changes needed were as follows.

1. Update the `elm-version` to 0.18
2. Change variables of the form `a'` to `a_`
    * Unfortunately, this made some pieces of code harder to read. (`a' _ _ _` vs `a_ _ _ _`).
3. Update the dependencies to the current versions.
4. Replace `Basics.snd` with `Tuple.second`
    * This was achieved by replacing `snd` with `second` and adding `import Tuple exposing (second)` to the top of [Internal.elm](src/Internal.elm).

All the changes were small and shouldn't impact the semantics of the package and I did not have any tests available for the package so I only checked for the ability to compile the code.

This should close issue #1.